### PR TITLE
fix #1  init command can't create some directories 

### DIFF
--- a/src/actions/init.js
+++ b/src/actions/init.js
@@ -59,9 +59,9 @@ module.exports = {
 		
 		var templateDir = `${path.dirname(require.main.filename)}/template`;
 
-		await fs.mkdirSync(`${appDir}/app/functions`, { recursive: true })		
-		await fs.mkdirSync(`${appDir}/app/resources`, { recursive: true })		
-		await fs.mkdirSync(`${appDir}/app/common`, { recursive: true })		
+		fs.mkdirsSync(`${appDir}/app/functions`)
+		fs.mkdirsSync(`${appDir}/app/resources`)
+		fs.mkdirsSync(`${appDir}/app/common`)
 		
 		fs.writeFileSync(`${appDir}/app/functions/.gitkeep`)
 		fs.writeFileSync(`${appDir}/app/resources/.gitkeep`)


### PR DESCRIPTION
fs-extra doesn't have `mkdirSync` method.
so,init command use normal fs module,But fs module can't create directory that parent directory is not exists.
I think init command should use `mkdirsSync` method